### PR TITLE
Specify the string encoding for UrlEncodedFormEntity

### DIFF
--- a/src/com/twinql/clojure/http.clj
+++ b/src/com/twinql/clojure/http.clj
@@ -499,7 +499,7 @@ If only a query parameter map is provided, it is included in the body.")
           (when ~'query
             (.setEntity http-verb#
                         (new UrlEncodedFormEntity
-                             (seq (map->name-value-pairs ~'query))))))
+                             (seq (map->name-value-pairs ~'query)) "UTF-8"))))
         (handle-http
           ~'parameters
           (adding-headers!


### PR DESCRIPTION
I use UTF-8 because the other encoding for URL-encode is UTF-8 (in l.109).

Fix that all Japanese characters are escaped to %3F.
For detail of this problem, please see [this bug report](https://github.com/mattrepl/clojure-twitter/issues/9).
